### PR TITLE
Typos on files and keeping requirements.txt

### DIFF
--- a/{{cookiecutter.repo_name}}/_CI/scripts/build
+++ b/{{cookiecutter.repo_name}}/_CI/scripts/build
@@ -35,8 +35,5 @@ for file in "${required_files[@]}"
         rm {{cookiecutter.repo_name}}/$file
     done
 
-echo "Removing requiremens.txt"
-rm requirements.txt
-
 echo "Removing dev-requiremens.txt"
 rm dev-requirements.txt

--- a/{{cookiecutter.repo_name}}/_CI/scripts/upload
+++ b/{{cookiecutter.repo_name}}/_CI/scripts/upload
@@ -1,6 +1,6 @@
 #!/bin/bash --login
 # we want all these files to exist in the actual package
-required_files=(".VERSION" "LICENSE" "AUTHORS.rst" "CONTRIBUTING.rst" "HISTORY.rst" "README.rst" "USAGE.rst" "Pipfile" "Pipfile.lock" "requirements.txt" "requirements_dev.txt")
+required_files=(".VERSION" "LICENSE" "AUTHORS.rst" "CONTRIBUTING.rst" "HISTORY.rst" "README.rst" "USAGE.rst" "Pipfile" "Pipfile.lock" "requirements.txt" "dev-requirements.txt")
 
 cd $(dirname $0)/../..
 
@@ -13,10 +13,10 @@ rm -rf build dist
 echo "Locking requirements to create up to date files"
 pipenv lock
 
-echo "Creating requiremens.txt"
+echo "Creating requirements.txt"
 ./_CI/bin/create_requirements.py default
 
-echo "Creating dev-requiremens.txt"
+echo "Creating dev-requirements.txt"
 ./_CI/bin/create_requirements.py develop
 
 
@@ -35,9 +35,6 @@ for file in "${required_files[@]}"
         rm {{cookiecutter.repo_name}}/$file
     done
 
-echo "Removing requiremens.txt"
-rm requirements.txt
-
-echo "Removing dev-requiremens.txt"
+echo "Removing dev-requirements.txt"
 rm dev-requirements.txt
 


### PR DESCRIPTION
* Wrong file names when building was breaking the upload scripts. 
* Typos on file names
* Also, keeping `requirements.txt` as Readthedocs need it when building the docs as it reads the repository in Git
 + info http://docs.readthedocs.io/en/latest/faq.html#my-project-isn-t-building-with-autodoc